### PR TITLE
make fth-bib independent of KOMA sciript

### DIFF
--- a/fth/fth-bib.sty
+++ b/fth/fth-bib.sty
@@ -28,7 +28,9 @@ maxnames=2]{biblatex}
     thresholdtype=lines
 ]{csquotes}
 
-\KOMAoption{bibliography}{totoc}
+\ifdefined\KOMAoption
+  \KOMAoption{bibliography}{totoc}
+\fi
 
 \SetCiteCommand{\autocite}
 


### PR DESCRIPTION
the package is setting a KOMAoption
from now on it is first checked whether is option *can* be set 
therefore fth-bib can now be used with other documentclasses, e. g. beamer