### PR TITLE
Feature/polyglossia 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ xelatex
 xelatex
 ```
 
-## Was das Paket (noch) nicht kann
-Hebräisch. Griechisch kann man ganz einfach als UTF-8 schreiben und sollte korrekt angezeigt werden. Hebräisch geht noch nicht. Dafür muss ich wohl von `babel` auf `polyglossia` umstellen, damit kenne ich mich aber noch nicht aus.
+## Griechisch und Hebräisch
+Griechisch und Hebräisch lassen sich auf 2 Arten nutzen:
+- Der Default-Font aus dem Pekt `fth-lsa` enthält die meisten Zeichen beider Sprachen, allerdings können masoretische Akzente nicht dargestellt werden. Verwendet man keine masoretischen Akzente, kann man ganz einfach Griechisch und Hebräisch in Unicode tippen und es sollte problemlos angezeigt werden.
+- Alternativ verwendet man das Paket `fth-lang`, das mit `polyglossia` und `fontspec` die Fonts [SBL Hebrew](https://www.sbl-site.org/educational/BiblicalFonts_SBLHebrew.aspx) und [SBL Greek](https://www.sbl-site.org/educational/BiblicalFonts_SBLGreek.aspx) einstellt, die mit `\heb{עִבְרִית}` und `\grk{κοινὴ}` verfügbar sind. Die beiden Fonts müssen auf dem System installiert oder im lokalen Verzeichnis abgelegt sein.
 
 ## Anmerkung zu Bibelstellen
 Die FTH-Leitlinien fordern zwar eine Fomrattierung entsprechend den Loccumer Richtlinien, die in Abschnitt 6.1 der Leitlinien angegebenen Abkürzungen entsprechen allerdings gar nicht den Loccumer Richtlinien (das Buch 1.Mose müsste z.B. Gen abgekürzt werden, nicht 1Mose). Bei Benutzung von \bibleverse formattiert das Paket fth-lsa Bibelstellen korrekt entsprechend den echten Loccumer Richtlinien, nicht jedoch wie in 6.1 der FTH-Leitlinien. Wem das zu riskant ist, kann die Option `tre` verwenden, die stattdessen entsprechend der TRE formattiert, was die FTH-Leitlinien ebenfalls erlauben.

--- a/example.tex
+++ b/example.tex
@@ -1,7 +1,11 @@
 % Beim Laden der documentclass können zwar Schrift- und Papiergröße angegeben werden, allerdings überschreibt das Paket fth-lsa
 \documentclass{scrreport}
 
-\usepackage[ngerman]{babel}
+\usepackage{fth/fth-lang}
+% Paket für Hebräisch und Griechisch, muss unbedingt vor den anderen Paketen geladen werden.
+% Erfordert Installation der Fonts SBL Hebrew und Greek: 
+% https://www.sbl-site.org/educational/BiblicalFonts_SBLHebrew.aspx
+% https://www.sbl-site.org/educational/BiblicalFonts_SBLGreek.aspx
 
 \usepackage{fth/fth-lsa}
 % Verfügbare Optionen für das Paket fth-lsa
@@ -39,7 +43,7 @@
 
 % \title, \author und \date müssen immer gesetzt sein, alle anderen Felder sind optional
 \title{Umsetzung der \enquote{Leitlinien für schriftliche Arbeiten an der FTH}}
-\subtitle{Ein Beispieldokument}
+\subtitle{Ein Beispieldokument mit \grk{κοινὴ} und \heb{עִבְרִית}}
 \thesistype{Übung}
 \course{Einführung ins wissenschaftliche Arbeiten}
 % Alternativ bei mehreren Fächern:
@@ -55,6 +59,7 @@
 \tableofcontents
 
 \chapter{Ein Kapitel}
+\label{chap:firstchapter}
 \section{Ein Abschnitt}
 \lipsum
 
@@ -68,11 +73,15 @@ Bibelstellen sollten entsprechend den Loccumer Richtlinien oder der TRE abgekür
 \section{Fußnoten}
 In diesem Abschnitt kommt mal eine Fußnote.\footnote{Das hier ist eine Fußnote. Sie geht über mehrere Zeilen, und sie sollten einen einzeiligen Zeilenabstand haben. \lipsum[1]} Jetzt nochmal einiger Text: \lipsum[1-9]\footnote{Das hier ist eine weitere Fußnote im selben Kapitel. Sie sollte fortlaufend numeriert werden.}
 
-\chapter{Noch ein Kapitel mit weiteren Fußnoten}
-Das hier ist ein neues Kapitel.\footnote{Das hier ist eine Fußnote im neuen Kapitel. Sie sollte trotzdem weiter numeriert werden und nicht die Nummer 1 erhalten}
+\chapter{Noch ein Kapitel mit weiteren Fußnoten und tollen Sprachen}
+Das hier ist ein neues Kapitel.\footnote{Das hier ist eine Fußnote im neuen Kapitel. Sie sollte trotzdem weiter numeriert werden und nicht die Nummer 1 erhalten}. Außerdem noch ein Rückverweis auf \autoref{chap:firstchapter}
 
-\section{Überschrift mit Griechischen Buchstaben: λόγος}
-Das funktioniert ja hervorragend! Und noch ein bisschen Griechisch im Text: πνευματος.
+\section{Überschrift mit Griechischen Buchstaben: \grk{λόγος}}
+\label{sec:greek}
+Das funktioniert ja hervorragend! Und noch ein bisschen Griechisch im Text: \grk{Ἐν ἀρχῇ ἦν ὁ λόγος, καὶ ὁ λόγος ἦν πρὸς τὸν θεόν, καὶ θεὸς ἦν ὁ λόγος.}
+
+\section{Überschrift mit Hebräischen Buchstaben: \heb{בְּרֵאשִׁ֖ית}}
+Etwas hebräischer Text: \heb{בְּרֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ׃}. In \autoref{sec:greek} gab's Griechisch.
 
 \chapter{Kapitel mit Zitaten}
 Hier könnte jetzt ein sinnvoller Text stehen. Aber es geht ja nur um die korrekte Form. Daher steht hier einfach irgendetwas. Jetzt kommt ein direktes Zitat. \citeauthor*{friesen} schreibt zum Thema Berufung: \blockcquote[][330]{friesen}{Rather than waiting for some kind of mystical \enquote{call} from God, every believer should respond to the revealed will of God by giving serious consideration to becoming a cross-cultural missionary.} Jetzt kommt noch ein Zitat aus demselben Werk: \blockcquote[][330]{friesen}{We don't need a call -- we've already been commissioned.} Weil dieses Zitat aus demselben Werk kommt und auf derselben Seite steht, sollte die Fußnote es einfach mit \enquote{ebd.} erwähnen.

--- a/example_handout.tex
+++ b/example_handout.tex
@@ -10,6 +10,7 @@
 % Für Literatur verwenden wir "fth-bib".
 \usepackage[authorsc]{fth-bib}
 % Hier muss der Pfad zur .bib Datei angegeben werden:
+% TODO Micha: Bib-Datei ebenfalls ablegen oder aus Beispiel entfernen
 \addbibresource{~/Nextcloud/Literatursammlung/lit.bib}
 
 \author{Micha Piertzik}

--- a/example_handout.tex
+++ b/example_handout.tex
@@ -1,6 +1,5 @@
 % scrartcl ist eine geeignete Klasse für bspw. Handouts.
-% headings=standardclasses hält die Klasse davon ab, die Fonts der Überschriften zu ändern, was wir benötigen, weil sonst kein hebräisch im Titel funktioniert!
-\documentclass[headings=standardclasses]{scrartcl}
+\documentclass{scrartcl}
 
 % Wir wollen griechisch und hebräisch nutzen, daher "fth-lang".
 % Voraussetzung dafür ist, dass die Fonts "SBL Hebrew" "SBL Greek" installiert sind!

--- a/fth/fth-lang.sty
+++ b/fth/fth-lang.sty
@@ -1,15 +1,11 @@
 % Umsetzung der Leitlinien für schrifliche Arbeiten an der FTH: Nutzung der Sprachen Griechisch und Hebräisch
 % Autor: Micha Piertzik
-\ProvidesPackage{fth-lang}[2023/12/21 Umsetzung der Leitlinien für schrifliche Arbeiten an der FTH Gießen: Nutzung der Sprachen Griechisch und Hebräisch]
+\ProvidesPackage{fth-lang}[2024/02/28 Umsetzung der Leitlinien für schrifliche Arbeiten an der FTH Gießen: Nutzung der Sprachen Griechisch und Hebräisch]
 
 % Es wird vorausgesetzt, dass die Fonts "SBL Hebrew" und "SBL Greek" istalliert sind! Download:
 %   https://www.sbl-site.org/educational/BiblicalFonts_SBLHebrew.aspx
 %   https://www.sbl-site.org/educational/BiblicalFonts_SBLGreek.aspx
 
-
-% ========================
-% Variablen für Optionen *
-% ========================
 % ===========================================================
 % Diese Pakete werden von anderen FTH-Pakten gebraucht,     *
 % müssen aber vor bidi (für Hebräisch nötig) geladen werden *
@@ -22,19 +18,20 @@
 % Sprachen-Einstellung *
 % ======================
 \RequirePackage{polyglossia}
-	\setmainlanguage{german}
-	\setotherlanguage[variant=american]{english}
-	\setotherlanguage[variant=ancient]{greek}
-	\setotherlanguage{hebrew} %vorher https://www.sbl-site.org/educational/BiblicalFonts_SBLHebrew.aspx installieren
+\setmainlanguage{german}
+\setotherlanguage[variant=american]{english}
+\setotherlanguage[variant=ancient]{greek}
+\setotherlanguage{hebrew}
 \newcommand{\heb}[1]{\texthebrew{#1}}
 \newcommand{\grk}[1]{\textgreek{#1}}
 
 
+% ========================
+% Fonts für die Sprachen *
+% ========================
 \RequirePackage{fontspec}
-	\newfontfamily{\greekfont}{SBL Greek}
-	\newfontfamily{\greekfontsf}{SBL Greek}
-	\newfontfamily{\hebrewfont}{SBL Hebrew}
-	\newfontfamily{\hebrewfontsf}{SBL Hebrew}
-
-
+\newfontfamily{\greekfont}{SBL Greek}
+\newfontfamily{\greekfontsf}{SBL Greek}
+\newfontfamily{\hebrewfont}{SBL Hebrew}
+\newfontfamily{\hebrewfontsf}{SBL Hebrew}
 

--- a/fth/fth-lang.sty
+++ b/fth/fth-lang.sty
@@ -6,7 +6,6 @@
 %   https://www.sbl-site.org/educational/BiblicalFonts_SBLHebrew.aspx
 %   https://www.sbl-site.org/educational/BiblicalFonts_SBLGreek.aspx
 
-% Bei KOMA-Script Klassen wird die Font der Überschrift geändert. Wenn man \heb{} oder \grk{} in Überschriften verwenden will, muss man bei er documentclass als Option "headings=standardclasses" angeben.
 
 % ========================
 % Variablen für Optionen *

--- a/fth/fth-lang.sty
+++ b/fth/fth-lang.sty
@@ -11,6 +11,17 @@
 % ========================
 % Variablen für Optionen *
 % ========================
+% ===========================================================
+% Diese Pakete werden von anderen FTH-Pakten gebraucht,     *
+% müssen aber vor bidi (für Hebräisch nötig) geladen werden *
+% ===========================================================
+\RequirePackage{geometry}
+\RequirePackage{multicol}
+\RequirePackage{hyperref}
+
+% ======================
+% Sprachen-Einstellung *
+% ======================
 \RequirePackage{polyglossia}
 	\setmainlanguage{german}
 	\setotherlanguage[variant=american]{english}

--- a/fth/fth-lang.sty
+++ b/fth/fth-lang.sty
@@ -30,8 +30,20 @@
 % Fonts für die Sprachen *
 % ========================
 \RequirePackage{fontspec}
-\newfontfamily{\greekfont}{SBL Greek}
-\newfontfamily{\greekfontsf}{SBL Greek}
-\newfontfamily{\hebrewfont}{SBL Hebrew}
-\newfontfamily{\hebrewfontsf}{SBL Hebrew}
+
+% Zunächst wird versucht, den Font über das System zu laden, andernfalls wird lokal nach einer passenden Datei gesucht (z.B. bei Overleaf nötig)
+\IfFontExistsTF{SBL Greek}{
+	\newfontfamily{\greekfont}{SBL Greek}
+	\newfontfamily{\greekfontsf}{SBL Greek}
+}{
+	\newfontfamily{\greekfont}{SBL_grk.ttf}
+	\newfontfamily{\greekfontsf}{SBL_grk.ttf}
+}
+\IfFontExistsTF{SBL Hebrew}{
+	\newfontfamily{\hebrewfont}{SBL Hebrew}
+	\newfontfamily{\hebrewfontsf}{SBL Hebrew}
+}{
+	\newfontfamily{\hebrewfont}{SBL_Hbrw.ttf}
+	\newfontfamily{\hebrewfontsf}{SBL_Hbrw.ttf}
+}
 

--- a/fth/fth-lsa.sty
+++ b/fth/fth-lsa.sty
@@ -196,7 +196,8 @@
 % ==============================================
 % Hyperref automatisch importieren ohne Farben *
 % ==============================================
-\RequirePackage[hidelinks]{hyperref}
+\RequirePackage{hyperref}
+\hypersetup{hidelinks,german}
 
 % ======================================
 % Text für Selbstständigkeitserklärung *


### PR DESCRIPTION
Ahoi, hab das ganze mal so angepasst, dass es mit fth-lsa und fth-bib läuft.
Habe nicht ganz verstanden, wozu `headings=standardclasses` nötig sein soll, bei mir funktioniert es sowohl lokal als auch auf Overleaf auch ohne (Ich bekomme zwar in Überschriften Warnings von wegen 
```
Font shape `TU/SBLGreek(0)/b/n' undefined
(Font)	using `TU/SBLGreek(0)/m/n' instead.
```
aber die kommen unabhängig von der Koma option.

Außerdem sorgt `headings=standardclasses`  für ein ganz blödes Format von Chapter headings in scrreport.
Wenn es immer gewollt wäre, kann man eine solche Option auch im Paket direkt mit `KOMAoption{headings}{standardclasses}`setzen statt sie beim Laden der Klasse angeben zu müssen.