### PR TITLE
füge aramäisch mit babylonischer Punktation als eigene Sprache hinzu

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ xelatex
 xelatex
 ```
 
-## Griechisch und Hebräisch
+## Griechisch, Hebräisch und Aramäisch
 Griechisch und Hebräisch lassen sich auf 2 Arten nutzen:
 - Der Default-Font aus dem Pekt `fth-lsa` enthält die meisten Zeichen beider Sprachen, allerdings können masoretische Akzente nicht dargestellt werden. Verwendet man keine masoretischen Akzente, kann man ganz einfach Griechisch und Hebräisch in Unicode tippen und es sollte problemlos angezeigt werden.
 - Alternativ verwendet man das Paket `fth-lang`, das mit `polyglossia` und `fontspec` die Fonts [SBL Hebrew](https://www.sbl-site.org/educational/BiblicalFonts_SBLHebrew.aspx) und [SBL Greek](https://www.sbl-site.org/educational/BiblicalFonts_SBLGreek.aspx) einstellt, die mit `\heb{עִבְרִית}` und `\grk{κοινὴ}` verfügbar sind. Die beiden Fonts müssen auf dem System installiert oder im lokalen Verzeichnis abgelegt sein.
+
+Aramäisch kann im Normalfall wie hebräisch verwendet werden. Will man aber babylonische Punktierung verwenden (etwa für Targum-Aramäisch), muss die Schriftart `EzraBab` auf dem System installiert sein oder als `EzraBab.ttf` im selben Verzeichnis liegen. Leider ist die Schriftart aktuell nicht frei zugänglich. Das ganze sieht dann im Code so aus: \tgaram{א֘ד֘ם} und wird im PDF mit den korrekten Vokalzeichen gerendert.
 
 ## Anmerkung zu Bibelstellen
 Die FTH-Leitlinien fordern zwar eine Fomrattierung entsprechend den Loccumer Richtlinien, die in Abschnitt 6.1 der Leitlinien angegebenen Abkürzungen entsprechen allerdings gar nicht den Loccumer Richtlinien (das Buch 1.Mose müsste z.B. Gen abgekürzt werden, nicht 1Mose). Bei Benutzung von \bibleverse formattiert das Paket fth-lsa Bibelstellen korrekt entsprechend den echten Loccumer Richtlinien, nicht jedoch wie in 6.1 der FTH-Leitlinien. Wem das zu riskant ist, kann die Option `tre` verwenden, die stattdessen entsprechend der TRE formattiert, was die FTH-Leitlinien ebenfalls erlauben.

--- a/example.tex
+++ b/example.tex
@@ -83,6 +83,10 @@ Das funktioniert ja hervorragend! Und noch ein bisschen Griechisch im Text: \grk
 \section{Überschrift mit Hebräischen Buchstaben: \heb{בְּרֵאשִׁ֖ית}}
 Etwas hebräischer Text: \heb{בְּרֵאשִׁ֖ית בָּרָ֣א אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ׃}. In \autoref{sec:greek} gab's Griechisch.
 
+% Der folgende Abschnitt enthält babylonische Punktierung, die nur funktioniert, wenn die Schriftart EzraBab installiert ist oder EzraBab.ttf im Verzeichnis liegt. Wenn das der Fall ist, dann einfach die folgenden Zeilen einkommentieren.
+%\section{Überschrift mit babylonischer Punktierung (Targum-Aramäisch): \tgaram{א֘ד֘ם}}
+%Und hier Gen 2,15 nach Targum Onqelos: \tgaram{ו֝דב֨ר יוי א֓ל֯ה֜ים י֘ת א֘ד֘ם ו֓א֨שר֜י֞יה ב֓ג֜ינ֓ת֘א ד֓ע֞ד֨ן ל֓מִפל֓ח֨ה ו֝למ֜ט֓ר֨ה׃}
+
 \chapter{Kapitel mit Zitaten}
 Hier könnte jetzt ein sinnvoller Text stehen. Aber es geht ja nur um die korrekte Form. Daher steht hier einfach irgendetwas. Jetzt kommt ein direktes Zitat. \citeauthor*{friesen} schreibt zum Thema Berufung: \blockcquote[][330]{friesen}{Rather than waiting for some kind of mystical \enquote{call} from God, every believer should respond to the revealed will of God by giving serious consideration to becoming a cross-cultural missionary.} Jetzt kommt noch ein Zitat aus demselben Werk: \blockcquote[][330]{friesen}{We don't need a call -- we've already been commissioned.} Weil dieses Zitat aus demselben Werk kommt und auf derselben Seite steht, sollte die Fußnote es einfach mit \enquote{ebd.} erwähnen.
 

--- a/fth/fth-lang.sty
+++ b/fth/fth-lang.sty
@@ -59,7 +59,7 @@
 	\IfFontExistsTF{EzraBab.ttf}{
 		\newfontfamily{\syriacfont}{EzraBab.ttf}
 		\newfontfamily{\syriacfontsf}{EzraBab.ttf}
-	}
+	}{}
 }
 
 

--- a/fth/fth-lang.sty
+++ b/fth/fth-lang.sty
@@ -1,10 +1,14 @@
 % Umsetzung der Leitlinien für schrifliche Arbeiten an der FTH: Nutzung der Sprachen Griechisch und Hebräisch
 % Autor: Micha Piertzik
-\ProvidesPackage{fth-lang}[2024/02/28 Umsetzung der Leitlinien für schrifliche Arbeiten an der FTH Gießen: Nutzung der Sprachen Griechisch und Hebräisch]
+\ProvidesPackage{fth-lang}[2024/02/28 Umsetzung der Leitlinien für schrifliche Arbeiten an der FTH Gießen: Nutzung der Sprachen Griechisch, Hebräisch und Aramäisch]
 
 % Es wird vorausgesetzt, dass die Fonts "SBL Hebrew" und "SBL Greek" istalliert sind! Download:
 %   https://www.sbl-site.org/educational/BiblicalFonts_SBLHebrew.aspx
 %   https://www.sbl-site.org/educational/BiblicalFonts_SBLGreek.aspx
+%
+% Aramäisch kann ohne Probleme als Hebärisch geschrieben werden.
+% Nur wenn babylonisch Punktation verwendet werden soll, muss der Befehl \tgaram{} verwendet werden.
+% Voraussetzung dafür ist aber, dass EzraBab installiert ist, eine Schriftart, die aktuell meines Wissens nicht frei zugänglich ist.
 
 % ===========================================================
 % Diese Pakete werden von anderen FTH-Pakten gebraucht,     *
@@ -22,8 +26,10 @@
 \setotherlanguage[variant=american]{english}
 \setotherlanguage[variant=ancient]{greek}
 \setotherlanguage{hebrew}
+\setotherlanguage{syriac}
 \newcommand{\heb}[1]{\texthebrew{#1}}
 \newcommand{\grk}[1]{\textgreek{#1}}
+\newcommand{\tgaram}[1]{\textsyriac{#1}}
 
 
 % ========================
@@ -46,4 +52,14 @@
 	\newfontfamily{\hebrewfont}{SBL_Hbrw.ttf}
 	\newfontfamily{\hebrewfontsf}{SBL_Hbrw.ttf}
 }
+\IfFontExistsTF{EzraBab}{
+	\newfontfamily{\syriacfont}{EzraBab}
+	\newfontfamily{\syriacfontsf}{EzraBab}
+}{
+	\IfFontExistsTF{EzraBab.ttf}{
+		\newfontfamily{\syriacfont}{EzraBab.ttf}
+		\newfontfamily{\syriacfontsf}{EzraBab.ttf}
+	}
+}
+
 


### PR DESCRIPTION
Aramäisch gibt es leider nicht als eigene Sprache bei polyglossia. Syriac ist ein aramäischer Dialekt, daher fand ich das halbwegs passend als Sprache zu verwenden und einfach die passende Schrift zu ergänzen.
Wenn in der Zukunft jemand mit Syriac arbeiten will, muss das ggf. nochmal angepasst werden.