### PR TITLE
Fake Targum aramaic with polyglossia and add real syriac

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -91,6 +91,10 @@ Etwas hebräischer Text: \heb{בְּרֵאשִׁ֖ית בָּרָ֣א אֱלֹה
 %\section{Überschrift mit babylonischer Punktierung (Targum-Aramäisch): \tgaram{א֘ד֘ם}}
 %Und hier Gen 2,15 nach Targum Onqelos: \tgaram{ו֝דב֨ר יוי א֓ל֯ה֜ים י֘ת א֘ד֘ם ו֓א֨שר֜י֞יה ב֓ג֜ינ֓ת֘א ד֓ע֞ד֨ן ל֓מִפל֓ח֨ה ו֝למ֜ט֓ר֨ה׃}
 
+% Der folgende Abschnitt enthält Syrische Schrift, die nur funktioniert wenn die Schfirtart Estrangelo Edessa installiert ist oder estre.ttf im Verzeichnis liegt. Wenn das der Fall ist, einfach die folgenden Zeilen einkommentieren.
+\section{Überschrift mit Syrisch: \syr{ܫܪ̈ܒܬܗܘܢ ܫܢܬܐ ܢܗ̈ܘܝܢ܂ ܘܒܨܦܪܐ ܐܝܟ ܥܘܦܝܐ ܬܚܠܦ} }
+Und Text in Syrisch: \syr{ܫܪ̈ܒܬܗܘܢ ܫܢܬܐ ܢܗ̈ܘܝܢ܂ ܘܒܨܦܪܐ ܐܝܟ ܥܘܦܝܐ ܬܚܠܦ} 
+
 \chapter{Kapitel mit Zitaten}
 Hier könnte jetzt ein sinnvoller Text stehen. Aber es geht ja nur um die korrekte Form. Daher steht hier einfach irgendetwas. Jetzt kommt ein direktes Zitat. \citeauthor*{friesen} schreibt zum Thema Berufung: \blockcquote[][330]{friesen}{Rather than waiting for some kind of mystical \enquote{call} from God, every believer should respond to the revealed will of God by giving serious consideration to becoming a cross-cultural missionary.} Jetzt kommt noch ein Zitat aus demselben Werk: \blockcquote[][330]{friesen}{We don't need a call -- we've already been commissioned.} Weil dieses Zitat aus demselben Werk kommt und auf derselben Seite steht, sollte die Fußnote es einfach mit \enquote{ebd.} erwähnen.
 

--- a/example.tex
+++ b/example.tex
@@ -92,8 +92,8 @@ Etwas hebräischer Text: \heb{בְּרֵאשִׁ֖ית בָּרָ֣א אֱלֹה
 %Und hier Gen 2,15 nach Targum Onqelos: \tgaram{ו֝דב֨ר יוי א֓ל֯ה֜ים י֘ת א֘ד֘ם ו֓א֨שר֜י֞יה ב֓ג֜ינ֓ת֘א ד֓ע֞ד֨ן ל֓מִפל֓ח֨ה ו֝למ֜ט֓ר֨ה׃}
 
 % Der folgende Abschnitt enthält Syrische Schrift, die nur funktioniert wenn die Schfirtart Estrangelo Edessa installiert ist oder estre.ttf im Verzeichnis liegt. Wenn das der Fall ist, einfach die folgenden Zeilen einkommentieren.
-\section{Überschrift mit Syrisch: \syr{ܫܪ̈ܒܬܗܘܢ ܫܢܬܐ ܢܗ̈ܘܝܢ܂ ܘܒܨܦܪܐ ܐܝܟ ܥܘܦܝܐ ܬܚܠܦ} }
-Und Text in Syrisch: \syr{ܫܪ̈ܒܬܗܘܢ ܫܢܬܐ ܢܗ̈ܘܝܢ܂ ܘܒܨܦܪܐ ܐܝܟ ܥܘܦܝܐ ܬܚܠܦ} 
+% \section{Überschrift mit Syrisch: \syr{ܫܪ̈ܒܬܗܘܢ ܫܢܬܐ ܢܗ̈ܘܝܢ܂ ܘܒܨܦܪܐ ܐܝܟ ܥܘܦܝܐ ܬܚܠܦ} }
+% Und Text in Syrisch: \syr{ܫܪ̈ܒܬܗܘܢ ܫܢܬܐ ܢܗ̈ܘܝܢ܂ ܘܒܨܦܪܐ ܐܝܟ ܥܘܦܝܐ ܬܚܠܦ} 
 
 \chapter{Kapitel mit Zitaten}
 Hier könnte jetzt ein sinnvoller Text stehen. Aber es geht ja nur um die korrekte Form. Daher steht hier einfach irgendetwas. Jetzt kommt ein direktes Zitat. \citeauthor*{friesen} schreibt zum Thema Berufung: \blockcquote[][330]{friesen}{Rather than waiting for some kind of mystical \enquote{call} from God, every believer should respond to the revealed will of God by giving serious consideration to becoming a cross-cultural missionary.} Jetzt kommt noch ein Zitat aus demselben Werk: \blockcquote[][330]{friesen}{We don't need a call -- we've already been commissioned.} Weil dieses Zitat aus demselben Werk kommt und auf derselben Seite steht, sollte die Fußnote es einfach mit \enquote{ebd.} erwähnen.

--- a/fth/fth-lang.sty
+++ b/fth/fth-lang.sty
@@ -28,9 +28,15 @@
 \setotherlanguage[variant=ancient]{greek}
 \setotherlanguage{hebrew}
 \setotherlanguage{syriac}
+
+% Aramaic is not supported by polyglossia, so it needs to be set up as a custom language
+\setotherlanguage{targumaramaic}
+\PolyglossiaSetup{targumaramaic}{direction=RL}
+
 \newcommand{\heb}[1]{\texthebrew{#1}}
 \newcommand{\grk}[1]{\textgreek{#1}}
-\newcommand{\tgaram}[1]{\textsyriac{#1}}
+\newcommand{\syr}[1]{\textsyriac{#1}}
+\newcommand{\tgaram}[1]{\texttargumaramaic{#1}}
 
 
 % ========================
@@ -54,12 +60,21 @@
 	\newfontfamily{\hebrewfontsf}{SBL_Hbrw.ttf}[AutoFakeBold=3]
 }
 \IfFontExistsTF{EzraBab}{
-	\newfontfamily{\syriacfont}{EzraBab}
-	\newfontfamily{\syriacfontsf}{EzraBab}
+	\newfontfamily{\targumaramaicfont}{EzraBab}
+	\newfontfamily{\targumaramaicfontsf}{EzraBab}
 }{
 	\IfFontExistsTF{EzraBab.ttf}{
-		\newfontfamily{\syriacfont}{EzraBab.ttf}
-		\newfontfamily{\syriacfontsf}{EzraBab.ttf}
+		\newfontfamily{\targumaramaicfont}{EzraBab.ttf}
+		\newfontfamily{\targumaramaicfontsf}{EzraBab.ttf}
+	}{}
+}
+\IfFontExistsTF{Estrangelo Edessa}{
+	\newfontfamily{\syriacfont}{Estrangelo Edessa}
+	\newfontfamily{\syriacfontsf}{Estrangelo Edessa}
+}{
+	\IfFontExistsTF{estre.ttf}{
+		\newfontfamily{\syriacfont}{estre.ttf}
+		\newfontfamily{\syriacfontsf}{estre.ttf}
 	}{}
 }
 


### PR DESCRIPTION
@pico40  ich habe festgestellt, dass man polyglossia tatsächlich auch eine Sprache "andrehen" kann, die es gar nicht supported, und mit den gleichen Befehlen wie sonst Fonts setzen kann usw.

Ich hab's bei mir lokal mal mit nem Hebräischen font probiert und es ging, dann deinen Code für Aramäisch entsprechend geändert. Damit können wir `syriac` für echtes Syrisch verwenden und müssen für Targum-Aramäisch nicht mal schummeln.

Bevor du den PR mergst, teste mal bitte, ob dein Targum-Aramäisch noch funktioniert. Da ich den Font nicht habe, konnte ich es nicht testen.