### PR TITLE
Feature/language switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Wenn das mit `TEXMFHOME` nicht funktioniert, kann man die `.sty`-Dateien auch ei
 ## Abhängigkeiten
 Die Pakete `fth-lsa` und `fth-bib` sollten mit einer Standard-LaTeX-2e-Installation problemlos funktionieren.
 
-Das Paket `fth-lang` (und `fth-nt-utils`, das `fth-lang` benötigt) benötigt die Fonts [SBL Hebrew](https://www.sbl-site.org/educational/BiblicalFonts_SBLHebrew.aspx) und [SBL Greek](https://www.sbl-site.org/educational/BiblicalFonts_SBLGreek.aspx), die unter den verlinkten Seiten heruntergeladen werden können. Die Fonts müssen ganz normal auf dem System installiert werden oder alternativ (bspw. auf Overleaf) als TTF-Datei im lokalen Verzeichnis abgelegt werden.
+Das Paket `fth-lang` (und `fth-nt-utils`, das `fth-lang` benötigt) benötigt bestimmte Fonts, siehe dazu unten.
 
 ## Pakete und Verwendung
 Das Repository stellt verschiedene Pakete zur Verfügung. Es sollten nur diejenigen, die wirklich benötigt werden, verwendet werden:
-- `fth-lang` konfiguriert die Verwendung passender Fonts für Griechisch und Hebräisch. Es sollte als erstes geladen werden.
+- `fth-lang` konfiguriert die Verwendung passender Fonts für Griechisch, Hebräisch und bei Bedarf Targum-Aramäisch und Syrisch. Es sollte als erstes geladen werden.
 - `fth-lsa` setzt die Formattierungs-Richtlinien aus den Leitlinien für schriftliche Arbeiten an der FTH (ohne Zitate) um.
 - `fth-bib` setzt die Richtlinien zur Formattierung von Zitaten und Literaturverzeichnis um.
 - `fth-nt-utils` stellt einige hilfreiche Befehle zur Arbeit mit neutestamentlichen Texten zur Verfügung, z.B. für Textkritik oder synoptische Vergleiche.
@@ -47,7 +47,11 @@ Griechisch und Hebräisch lassen sich auf 2 Arten nutzen:
 - Der Default-Font aus dem Pekt `fth-lsa` enthält die meisten Zeichen beider Sprachen, allerdings können masoretische Akzente nicht dargestellt werden. Verwendet man keine masoretischen Akzente, kann man ganz einfach Griechisch und Hebräisch in Unicode tippen und es sollte problemlos angezeigt werden.
 - Alternativ verwendet man das Paket `fth-lang`, das mit `polyglossia` und `fontspec` die Fonts [SBL Hebrew](https://www.sbl-site.org/educational/BiblicalFonts_SBLHebrew.aspx) und [SBL Greek](https://www.sbl-site.org/educational/BiblicalFonts_SBLGreek.aspx) einstellt, die mit `\heb{עִבְרִית}` und `\grk{κοινὴ}` verfügbar sind. Die beiden Fonts müssen auf dem System installiert oder im lokalen Verzeichnis abgelegt sein.
 
-Aramäisch kann im Normalfall wie hebräisch verwendet werden. Will man aber babylonische Punktierung verwenden (etwa für Targum-Aramäisch), muss die Schriftart `EzraBab` auf dem System installiert sein oder als `EzraBab.ttf` im selben Verzeichnis liegen. Leider ist die Schriftart aktuell nicht frei zugänglich. Das ganze sieht dann im Code so aus: \tgaram{א֘ד֘ם} und wird im PDF mit den korrekten Vokalzeichen gerendert.
+Aramäisch kann im Normalfall wie hebräisch verwendet werden. Will man aber babylonische Punktierung verwenden (etwa für Targum-Aramäisch), muss die Schriftart `EzraBab` auf dem System installiert sein oder als `EzraBab.ttf` im selben Verzeichnis liegen. Leider ist die Schriftart aktuell nicht frei zugänglich. Das ganze sieht dann im Code so aus: `\tgaram{א֘ד֘ם}` und wird im PDF mit den korrekten Vokalzeichen gerendert.
+
+Außerdem kann optional Syrisch verwendet werden. Dazu muss die Schriftart `Estrangelo Edessa` installiert sein oder als `estre.ttf` bereit liegen. Verwendet wird die Sprache dann mit `\syr{ܫܪ̈ܒܬܗܘܢ}`.
+
+Um Kompilierzeit beim Suchen der Fonts zu sparen, sind Aramäisch und Syrisch per Default deaktiviert. Sie können beim Laden des Pakets mit `\usepackage[syr=true,tgaram]{fth-lang}` aktiviert werden. Wenn Griechisch und Hebräisch nicht benötigt werden, können sie analog mit `\usepackage[grk=false,heb=false]{fth-lang}` deaktiviert werden.
 
 ## Anmerkung zu Bibelstellen
 Die FTH-Leitlinien fordern zwar eine Fomrattierung entsprechend den Loccumer Richtlinien, die in Abschnitt 6.1 der Leitlinien angegebenen Abkürzungen entsprechen allerdings gar nicht den Loccumer Richtlinien (das Buch 1.Mose müsste z.B. Gen abgekürzt werden, nicht 1Mose). Bei Benutzung von \bibleverse formattiert das Paket fth-lsa Bibelstellen korrekt entsprechend den echten Loccumer Richtlinien, nicht jedoch wie in 6.1 der FTH-Leitlinien. Wem das zu riskant ist, kann die Option `tre` verwenden, die stattdessen entsprechend der TRE formattiert, was die FTH-Leitlinien ebenfalls erlauben.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Aramäisch kann im Normalfall wie hebräisch verwendet werden. Will man aber bab
 
 Außerdem kann optional Syrisch verwendet werden. Dazu muss die Schriftart `Estrangelo Edessa` installiert sein oder als `estre.ttf` bereit liegen. Verwendet wird die Sprache dann mit `\syr{ܫܪ̈ܒܬܗܘܢ}`.
 
-Um Kompilierzeit beim Suchen der Fonts zu sparen, sind Aramäisch und Syrisch per Default deaktiviert. Sie können beim Laden des Pakets mit `\usepackage[syr=true,tgaram]{fth-lang}` aktiviert werden. Wenn Griechisch und Hebräisch nicht benötigt werden, können sie analog mit `\usepackage[grk=false,heb=false]{fth-lang}` deaktiviert werden.
+Um Kompilierzeit beim Suchen der Fonts zu sparen, sind Aramäisch und Syrisch per Default deaktiviert. Sie können beim Laden des Pakets mit `\usepackage[syr=true,tgaram=true]{fth-lang}` aktiviert werden. Wenn Griechisch und Hebräisch nicht benötigt werden, können sie analog mit `\usepackage[grk=false,heb=false]{fth-lang}` deaktiviert werden.
 
 ## Anmerkung zu Bibelstellen
 Die FTH-Leitlinien fordern zwar eine Fomrattierung entsprechend den Loccumer Richtlinien, die in Abschnitt 6.1 der Leitlinien angegebenen Abkürzungen entsprechen allerdings gar nicht den Loccumer Richtlinien (das Buch 1.Mose müsste z.B. Gen abgekürzt werden, nicht 1Mose). Bei Benutzung von \bibleverse formattiert das Paket fth-lsa Bibelstellen korrekt entsprechend den echten Loccumer Richtlinien, nicht jedoch wie in 6.1 der FTH-Leitlinien. Wem das zu riskant ist, kann die Option `tre` verwenden, die stattdessen entsprechend der TRE formattiert, was die FTH-Leitlinien ebenfalls erlauben.

--- a/example.tex
+++ b/example.tex
@@ -98,8 +98,8 @@ Etwas hebräischer Text: \heb{בְּרֵאשִׁ֖ית בָּרָ֣א אֱלֹה
 %Und hier Gen 2,15 nach Targum Onqelos: \tgaram{ו֝דב֨ר יוי א֓ל֯ה֜ים י֘ת א֘ד֘ם ו֓א֨שר֜י֞יה ב֓ג֜ינ֓ת֘א ד֓ע֞ד֨ן ל֓מִפל֓ח֨ה ו֝למ֜ט֓ר֨ה׃}
 
 % Der folgende Abschnitt enthält Syrische Schrift, die nur funktioniert wenn die Schfirtart Estrangelo Edessa installiert ist oder estre.ttf im Verzeichnis liegt. Wenn das der Fall ist, einfach die folgenden Zeilen einkommentieren.
-\section{Überschrift mit Syrisch: \syr{ܫܪ̈ܒܬܗܘܢ ܫܢܬܐ ܢܗ̈ܘܝܢ܂ ܘܒܨܦܪܐ ܐܝܟ ܥܘܦܝܐ ܬܚܠܦ} }
-Und Text in Syrisch: \syr{ܫܪ̈ܒܬܗܘܢ ܫܢܬܐ ܢܗ̈ܘܝܢ܂ ܘܒܨܦܪܐ ܐܝܟ ܥܘܦܝܐ ܬܚܠܦ} 
+% \section{Überschrift mit Syrisch: \syr{ܫܪ̈ܒܬܗܘܢ ܫܢܬܐ ܢܗ̈ܘܝܢ܂ ܘܒܨܦܪܐ ܐܝܟ ܥܘܦܝܐ ܬܚܠܦ} }
+% Und Text in Syrisch: \syr{ܫܪ̈ܒܬܗܘܢ ܫܢܬܐ ܢܗ̈ܘܝܢ܂ ܘܒܨܦܪܐ ܐܝܟ ܥܘܦܝܐ ܬܚܠܦ} 
 
 \chapter{Kapitel mit Zitaten}
 Hier könnte jetzt ein sinnvoller Text stehen. Aber es geht ja nur um die korrekte Form. Daher steht hier einfach irgendetwas. Jetzt kommt ein direktes Zitat. \citeauthor*{friesen} schreibt zum Thema Berufung: \blockcquote[][330]{friesen}{Rather than waiting for some kind of mystical \enquote{call} from God, every believer should respond to the revealed will of God by giving serious consideration to becoming a cross-cultural missionary.} Jetzt kommt noch ein Zitat aus demselben Werk: \blockcquote[][330]{friesen}{We don't need a call -- we've already been commissioned.} Weil dieses Zitat aus demselben Werk kommt und auf derselben Seite steht, sollte die Fußnote es einfach mit \enquote{ebd.} erwähnen.

--- a/example.tex
+++ b/example.tex
@@ -6,6 +6,12 @@
 % Erfordert Installation der Fonts SBL Hebrew und Greek: 
 % https://www.sbl-site.org/educational/BiblicalFonts_SBLHebrew.aspx
 % https://www.sbl-site.org/educational/BiblicalFonts_SBLGreek.aspx
+% Außerdem sind auch Targum-Aramäisch (mit babylonischer Punktierung) mit dem Font EzraBab
+% und Syrisch mit dem Font Estrangelo Edessa nutzbar.
+% Griechisch, Hebräisch, Targum-Aramäisch und Syrisch sind jeweils über die Paket-Optionen
+% grk, heb, tgaram und syr ein- und ausschaltbar, also z.B.
+% \usepackage[grk=false,syr=true]{fth-lang}.
+% Dabei sind Griechisch und Hebräisch per Default aktiviert, Targum-Aramäisch und Syrisch nicht.
 
 \usepackage{fth/fth-lsa}
 % Verfügbare Optionen für das Paket fth-lsa
@@ -92,8 +98,8 @@ Etwas hebräischer Text: \heb{בְּרֵאשִׁ֖ית בָּרָ֣א אֱלֹה
 %Und hier Gen 2,15 nach Targum Onqelos: \tgaram{ו֝דב֨ר יוי א֓ל֯ה֜ים י֘ת א֘ד֘ם ו֓א֨שר֜י֞יה ב֓ג֜ינ֓ת֘א ד֓ע֞ד֨ן ל֓מִפל֓ח֨ה ו֝למ֜ט֓ר֨ה׃}
 
 % Der folgende Abschnitt enthält Syrische Schrift, die nur funktioniert wenn die Schfirtart Estrangelo Edessa installiert ist oder estre.ttf im Verzeichnis liegt. Wenn das der Fall ist, einfach die folgenden Zeilen einkommentieren.
-% \section{Überschrift mit Syrisch: \syr{ܫܪ̈ܒܬܗܘܢ ܫܢܬܐ ܢܗ̈ܘܝܢ܂ ܘܒܨܦܪܐ ܐܝܟ ܥܘܦܝܐ ܬܚܠܦ} }
-% Und Text in Syrisch: \syr{ܫܪ̈ܒܬܗܘܢ ܫܢܬܐ ܢܗ̈ܘܝܢ܂ ܘܒܨܦܪܐ ܐܝܟ ܥܘܦܝܐ ܬܚܠܦ} 
+\section{Überschrift mit Syrisch: \syr{ܫܪ̈ܒܬܗܘܢ ܫܢܬܐ ܢܗ̈ܘܝܢ܂ ܘܒܨܦܪܐ ܐܝܟ ܥܘܦܝܐ ܬܚܠܦ} }
+Und Text in Syrisch: \syr{ܫܪ̈ܒܬܗܘܢ ܫܢܬܐ ܢܗ̈ܘܝܢ܂ ܘܒܨܦܪܐ ܐܝܟ ܥܘܦܝܐ ܬܚܠܦ} 
 
 \chapter{Kapitel mit Zitaten}
 Hier könnte jetzt ein sinnvoller Text stehen. Aber es geht ja nur um die korrekte Form. Daher steht hier einfach irgendetwas. Jetzt kommt ein direktes Zitat. \citeauthor*{friesen} schreibt zum Thema Berufung: \blockcquote[][330]{friesen}{Rather than waiting for some kind of mystical \enquote{call} from God, every believer should respond to the revealed will of God by giving serious consideration to becoming a cross-cultural missionary.} Jetzt kommt noch ein Zitat aus demselben Werk: \blockcquote[][330]{friesen}{We don't need a call -- we've already been commissioned.} Weil dieses Zitat aus demselben Werk kommt und auf derselben Seite steht, sollte die Fußnote es einfach mit \enquote{ebd.} erwähnen.

--- a/fth/fth-lang.sty
+++ b/fth/fth-lang.sty
@@ -19,63 +19,107 @@
 \RequirePackage{hyperref}
 \RequirePackage{xcolor}
 
-% ======================
-% Sprachen-Einstellung *
-% ======================
+% ===========================================================
+% Optionen des Pakets zum Ein- und Ausschalten von Sprachen *
+% ===========================================================
+% Paket um Optionen auszuwerten
+\RequirePackage{xkeyval}
+
+% Deklaration der Variablen für Griechisch, Hebräisch, Targum-Aramäisch und Syrisch
+\newif\ifheb
+\newif\ifgrk
+\newif\iftgaram
+\newif\ifsyr
+
+% Default-Werte: Griechisch und Hebräisch an, Aramäisch und Syrisch aus
+\hebtrue
+\grktrue
+\tgaramfalse
+\syrfalse
+
+% Verarbeitung der Optionen
+\DeclareOptionX{heb}[true]{\csname heb#1\endcsname}
+\DeclareOptionX{grk}[true]{\csname grk#1\endcsname}
+\DeclareOptionX{tgaram}[false]{\csname tgaram#1\endcsname}
+\DeclareOptionX{syr}[false]{\csname syr#1\endcsname}
+
+\ProcessOptionsX
+
+
+% ====================================
+% Sprachen-Einstellung (inkl. Fonts) *
+% ====================================
 \RequirePackage{polyglossia}
-\setmainlanguage{german}
-\setotherlanguage[variant=american]{english}
-\setotherlanguage[variant=ancient]{greek}
-\setotherlanguage{hebrew}
-\setotherlanguage{syriac}
-
-% Aramaic is not supported by polyglossia, so it needs to be set up as a custom language
-\setotherlanguage{targumaramaic}
-\PolyglossiaSetup{targumaramaic}{direction=RL}
-
-\newcommand{\heb}[1]{\texthebrew{#1}}
-\newcommand{\grk}[1]{\textgreek{#1}}
-\newcommand{\syr}[1]{\textsyriac{#1}}
-\newcommand{\tgaram}[1]{\texttargumaramaic{#1}}
-
-
-% ========================
-% Fonts für die Sprachen *
-% ========================
 \RequirePackage{fontspec}
 
-% Zunächst wird versucht, den Font über das System zu laden, andernfalls wird lokal nach einer passenden Datei gesucht (z.B. bei Overleaf nötig)
-\IfFontExistsTF{SBL Greek}{
-	\newfontfamily{\greekfont}{SBL Greek}[AutoFakeBold=5,AutoFakeSlant=0.2]
-	\newfontfamily{\greekfontsf}{SBL Greek}[AutoFakeBold=5,AutoFakeSlant=0.2]
-}{
-	\newfontfamily{\greekfont}{SBL_grk.ttf}[AutoFakeBold=5,AutoFakeSlant=0.2]
-	\newfontfamily{\greekfontsf}{SBL_grk.ttf}[AutoFakeBold=5,AutoFakeSlant=0.2]
-}
-\IfFontExistsTF{SBL Hebrew}{
-	\newfontfamily{\hebrewfont}{SBL Hebrew}[AutoFakeBold=3]
-	\newfontfamily{\hebrewfontsf}{SBL Hebrew}[AutoFakeBold=3]
-}{
-	\newfontfamily{\hebrewfont}{SBL_Hbrw.ttf}[AutoFakeBold=3]
-	\newfontfamily{\hebrewfontsf}{SBL_Hbrw.ttf}[AutoFakeBold=3]
-}
-\IfFontExistsTF{EzraBab}{
-	\newfontfamily{\targumaramaicfont}{EzraBab}
-	\newfontfamily{\targumaramaicfontsf}{EzraBab}
-}{
-	\IfFontExistsTF{EzraBab.ttf}{
-		\newfontfamily{\targumaramaicfont}{EzraBab.ttf}
-		\newfontfamily{\targumaramaicfontsf}{EzraBab.ttf}
-	}{}
-}
-\IfFontExistsTF{Estrangelo Edessa}{
-	\newfontfamily{\syriacfont}{Estrangelo Edessa}
-	\newfontfamily{\syriacfontsf}{Estrangelo Edessa}
-}{
-	\IfFontExistsTF{estre.ttf}{
-		\newfontfamily{\syriacfont}{estre.ttf}
-		\newfontfamily{\syriacfontsf}{estre.ttf}
-	}{}
-}
+% Deutsch und Englisch werden immer geladen
+% TODO: Package-Option, Englisch als mainlanguage einzustellen
+\setmainlanguage{german}
+\setotherlanguage[variant=american]{english}
 
+% Beim Laden der Fonts wird zunächst versucht, den Font über das System zu laden
+% Andernfalls wird lokal nach einer passenden Datei gesucht (z.B. bei Overleaf nötig)
+
+\ifgrk
+	\setotherlanguage[variant=ancient]{greek}
+
+	\IfFontExistsTF{SBL Greek}{
+		\newfontfamily{\greekfont}{SBL Greek}[AutoFakeBold=5,AutoFakeSlant=0.2]
+		\newfontfamily{\greekfontsf}{SBL Greek}[AutoFakeBold=5,AutoFakeSlant=0.2]
+	}{
+		\newfontfamily{\greekfont}{SBL_grk.ttf}[AutoFakeBold=5,AutoFakeSlant=0.2]
+		\newfontfamily{\greekfontsf}{SBL_grk.ttf}[AutoFakeBold=5,AutoFakeSlant=0.2]
+	}
+
+	\newcommand{\grk}[1]{\textgreek{#1}}
+\fi
+
+\ifheb
+	\setotherlanguage{hebrew}
+
+	\IfFontExistsTF{SBL Hebrew}{
+		\newfontfamily{\hebrewfont}{SBL Hebrew}[AutoFakeBold=3]
+		\newfontfamily{\hebrewfontsf}{SBL Hebrew}[AutoFakeBold=3]
+	}{
+		\newfontfamily{\hebrewfont}{SBL_Hbrw.ttf}[AutoFakeBold=3]
+		\newfontfamily{\hebrewfontsf}{SBL_Hbrw.ttf}[AutoFakeBold=3]
+	}
+
+	\newcommand{\heb}[1]{\texthebrew{#1}}
+\fi
+
+
+\iftgaram
+	% Aramaic is not supported by polyglossia, so it needs to be set up as a custom language
+	\setotherlanguage{targumaramaic}
+	\PolyglossiaSetup{targumaramaic}{direction=RL}
+
+	\IfFontExistsTF{EzraBab}{
+		\newfontfamily{\targumaramaicfont}{EzraBab}
+		\newfontfamily{\targumaramaicfontsf}{EzraBab}
+	}{
+		\IfFontExistsTF{EzraBab.ttf}{
+			\newfontfamily{\targumaramaicfont}{EzraBab.ttf}
+			\newfontfamily{\targumaramaicfontsf}{EzraBab.ttf}
+		}{}
+	}
+
+	\newcommand{\tgaram}[1]{\texttargumaramaic{#1}}
+\fi
+
+\ifsyr
+	\setotherlanguage{syriac}
+
+	\IfFontExistsTF{Estrangelo Edessa}{
+		\newfontfamily{\syriacfont}{Estrangelo Edessa}
+		\newfontfamily{\syriacfontsf}{Estrangelo Edessa}
+	}{
+		\IfFontExistsTF{estre.ttf}{
+			\newfontfamily{\syriacfont}{estre.ttf}
+			\newfontfamily{\syriacfontsf}{estre.ttf}
+		}{}
+	}
+
+	\newcommand{\syr}[1]{\textsyriac{#1}}
+\fi
 


### PR DESCRIPTION
Ich habe mal bei `fth-lang` Optionen eingebaut, mit denen man Griechisch, Hebräisch, Aramäisch und Syrisch an- und Ausschalten kann.
Das Suchen von nicht auf dem System vorhandenen Fonts kostet nämlich immer mehrere Sekunden Kompilierzeit, die man so leicht einsparen kann.
Ich hab mal Griechisch und Hebräisch per Default (also ohne Angabe von Optionen) an, Syrsich und Aramäisch aus, d.h. bei deinen Dokumenten mit Aramäisch müsstest du es per Option explizit einschalten.
Teste mal bitte ob das so bei dir läuft.