### PR TITLE
Set bibliography style for online entries explicitly to prevent additional fields being shown

### DIFF
--- a/fth/fth-bib.sty
+++ b/fth/fth-bib.sty
@@ -230,6 +230,19 @@ maxnames=2]{biblatex}
     {}%
   \usebibmacro{finentry}}
 
+\DeclareBibliographyDriver{online}{%
+  \usebibmacro{bibindex}%
+  \usebibmacro{begentry}%
+  \usebibmacro{author}%
+  \newunit\newblock
+  \printfield{title}%
+  \newunit\newblock
+  \printfield{url}%
+  \setunit{\addspace}
+  \usebibmacro{urldate}
+  \usebibmacro{finentry}
+}
+
 \DeclareBibliographyDriver{collection}{%
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%

--- a/fth/fth-bib.sty
+++ b/fth/fth-bib.sty
@@ -238,7 +238,7 @@ maxnames=2]{biblatex}
   \printfield{title}%
   \newunit\newblock
   \printfield{url}%
-  \setunit{\addspace}
+  \setunit*{\addspace}
   \usebibmacro{urldate}
   \usebibmacro{finentry}
 }

--- a/fth/fth-bib.sty
+++ b/fth/fth-bib.sty
@@ -61,7 +61,8 @@ maxnames=2]{biblatex}
 %   urlfrom = {online unter},
 }
 
-%\DeclareFieldFormat{url}{\mbox{\url{#1}}}
+% disable "URL:" Prefix to url in @online
+\DeclareFieldFormat{url}{\url{#1}}
 \appto{\biburlsetup}{\renewcommand*{\UrlFont}{\normalfont\itshape}}
 
 \renewbibmacro*{publisher+location+date}{%


### PR DESCRIPTION
Wenn bspw. zusätzlich zu urldate noch date gesetzt war, wurde das fälschlicherweise auch angezeigt