### PR TITLE
Fix compile error because of multiple packages depending on fmtcount

### DIFF
--- a/fth/fth-lang.sty
+++ b/fth/fth-lang.sty
@@ -13,11 +13,14 @@
 % ===========================================================
 % Diese Pakete werden von anderen FTH-Pakten gebraucht,     *
 % müssen aber vor bidi (für Hebräisch nötig) geladen werden *
+% oder bevor die Sprache auf Deutsch gesetzt wird           *
 % ===========================================================
 \RequirePackage{geometry}
 \RequirePackage{multicol}
 \RequirePackage{hyperref}
 \RequirePackage{xcolor}
+\RequirePackage{bibleref}
+\RequirePackage{bibleref-german}
 
 % ===========================================================
 % Optionen des Pakets zum Ein- und Ausschalten von Sprachen *

--- a/fth/fth-lsa.sty
+++ b/fth/fth-lsa.sty
@@ -260,7 +260,6 @@
 \renewcommand*{\maketitle}{\fth@maketitle}
 
 % Restore maketitle after something in \begin{document} messes it up
-\end{document}
 \AtBeginDocument{%
   \renewcommand*{\maketitle}{\fth@maketitle}%
 }

--- a/fth/fth-lsa.sty
+++ b/fth/fth-lsa.sty
@@ -189,7 +189,7 @@
 
 
 
-\renewcommand*{\maketitle}{
+\newcommand*{\fth@maketitle}{
 \begin{titlepage}
     \begin{center}
     %%% Die Zeilen für titlehead, subject, title, subtitle und author sind immer vorhanden (spacing)
@@ -255,6 +255,14 @@
 
     \end{center}
 \end{titlepage}
+}
+
+\renewcommand*{\maketitle}{\fth@maketitle}
+
+% Restore maketitle after something in \begin{document} messes it up
+\end{document}
+\AtBeginDocument{%
+  \renewcommand*{\maketitle}{\fth@maketitle}%
 }
 
 % ==============================================


### PR DESCRIPTION
Seit ich vor ein paar Tagen mit `tlmgr` meine Pakete updated habe, macht `fmtcount` Faxen weil es sowohl von `polyglossia`  als auch von `bibleref-german` geladen wird. Die Lösung ist, bibleref-german vor polyglossia zu laden